### PR TITLE
Fix array type questions repeating header issue

### DIFF
--- a/upload/templates/watson_conventional_constructs/template.css
+++ b/upload/templates/watson_conventional_constructs/template.css
@@ -1646,3 +1646,11 @@ span.hide-tip div.error {
 .abstract-answers {
     padding-bottom: 20px;
 }
+
+
+
+/* Fix array type repeating header issue */
+.dontread.repeat.headings {
+    display: none;
+}
+

--- a/upload/templates/watson_dass/template.css
+++ b/upload/templates/watson_dass/template.css
@@ -1653,3 +1653,11 @@ span.hide-tip div.error {
 .abstract-answers {
     padding-bottom: 20px;
 }
+
+
+
+/* Fix array type repeating header issue */
+.dontread.repeat.headings {
+    display: none;
+}
+

--- a/upload/templates/watson_personal_constructs_copy_me/template.css
+++ b/upload/templates/watson_personal_constructs_copy_me/template.css
@@ -1644,3 +1644,10 @@ span.hide-tip div.error {
 .abstract-answers {
     padding-bottom: 20px;
 }
+
+
+/* Fix array type repeating header issue */
+.dontread.repeat.headings {
+    display: none;
+}
+


### PR DESCRIPTION
Hi @jackwarner

In troubleshooting your LimeSurvey fork at OISE, I noticed that array-type questions in the customized survey templates you authorized exhibit the repeated header issue. An example of such undesirable behaviour is included in the screenshot attached to this message.
- [Improperly rendered array type question](http://i.imgur.com/ha1WiVW.png)
- [Correctly rendered array type question after this PR is applied](http://i.imgur.com/90u1vxw.png)
  Please feel free to review the diff and accept/tweak/reject to your official Watson LimeSurvey fork.

Thanks,
@rouben
